### PR TITLE
Updated swagger response to respected serializer

### DIFF
--- a/swaggerpetstore/core/swagger/swagger_pets.py
+++ b/swaggerpetstore/core/swagger/swagger_pets.py
@@ -7,6 +7,7 @@ from drf_spectacular.utils import (
     extend_schema_view,
 )
 
+from pets.api.serializers import PetSerializer
 from swaggerpetstore.core import constants
 from swaggerpetstore.core.utils import api_response
 
@@ -40,14 +41,7 @@ def swagger_pet_modelviewset():
             responses={
                 200: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=pet_serializer_response,
-                            status_codes=["200"],
-                        )
-                    ],
+                    response=PetSerializer,
                 ),
                 400: OpenApiResponse(description="Invalid ID supplied"),
                 404: OpenApiResponse(description="Pet not found"),
@@ -59,14 +53,7 @@ def swagger_pet_modelviewset():
             responses={
                 201: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=pet_serializer_response,
-                            status_codes=["201"],
-                        )
-                    ],
+                    response=PetSerializer,
                 ),
                 404: OpenApiResponse(description="Bad Request"),
             },
@@ -77,14 +64,7 @@ def swagger_pet_modelviewset():
             responses={
                 200: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=pet_serializer_response,
-                            status_codes=["200"],
-                        )
-                    ],
+                    response=PetSerializer,
                 ),
                 400: OpenApiResponse(description="Invalid ID supplied"),
                 404: OpenApiResponse(description="Pet not found"),
@@ -168,14 +148,7 @@ def swagger_pet_viewset():
             responses={
                 200: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=pet_serializer_response,
-                            status_codes=["200"],
-                        )
-                    ],
+                    response=PetSerializer,
                 ),
                 400: OpenApiResponse(description="Invalid input"),
                 404: OpenApiResponse(description="Pet not found"),
@@ -206,14 +179,7 @@ def swagger_pet_by_tags():
             responses={
                 200: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=[pet_serializer_response],
-                            status_codes=["200"],
-                        )
-                    ],
+                    response=PetSerializer,
                 ),
                 400: OpenApiResponse(description="Invalid tag value"),
             },
@@ -243,14 +209,7 @@ def swagger_pet_by_status():
             responses={
                 200: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=[pet_serializer_response],
-                            status_codes=["200"],
-                        )
-                    ],
+                    response=PetSerializer,
                 ),
                 400: OpenApiResponse(description="Invalid status value"),
             },

--- a/swaggerpetstore/core/swagger/swagger_stores.py
+++ b/swaggerpetstore/core/swagger/swagger_stores.py
@@ -6,6 +6,8 @@ from drf_spectacular.utils import (
     extend_schema_view,
 )
 
+from stores.api.serializers import OrderSerializer
+
 """
 API response example of InventoryAPIView.
     path: stores.api.view.InventoryAPIView
@@ -14,19 +16,6 @@ inventory_api_response = {
     "available": "string",
     "pending": "string",
     "sold": "string",
-}
-
-"""
-OrderSerializer example
-    path: stores.api.serializers.OrderSerializer
-"""
-order_serializer_response = {
-    "id": 0,
-    "quantity": 0,
-    "ship_date": "2022-10-13T15:25:32.425Z",
-    "status": "placed",
-    "complete": True,
-    "pet": 0,
 }
 
 
@@ -70,14 +59,7 @@ def swagger_order_createmixin():
             responses={
                 200: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=order_serializer_response,
-                            status_codes=["200"],
-                        )
-                    ],
+                    response=OrderSerializer,
                 ),
                 400: OpenApiResponse(description="Invalid input"),
             },
@@ -98,14 +80,7 @@ def swagger_order_retrivedestroy():
             responses={
                 200: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=order_serializer_response,
-                            status_codes=["200"],
-                        )
-                    ],
+                    response=OrderSerializer,
                 ),
                 404: OpenApiResponse(description="Order not found"),
             },

--- a/swaggerpetstore/core/swagger/swagger_users.py
+++ b/swaggerpetstore/core/swagger/swagger_users.py
@@ -40,14 +40,7 @@ def swagger_users_create():
             responses={
                 200: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=user_serializer_response,
-                            status_codes=["200"],
-                        )
-                    ],
+                    response=UserSerializer,
                 ),
                 400: OpenApiResponse(description="Invalid input"),
                 401: OpenApiResponse(description="Unauthorized"),
@@ -68,14 +61,7 @@ def swagger_users_retriveupdatedestroy():
             responses={
                 200: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=user_serializer_response,
-                            status_codes=["200"],
-                        )
-                    ],
+                    response=UserSerializer,
                 ),
                 401: OpenApiResponse(description="Unauthorized"),
                 404: OpenApiResponse(description="User not found"),
@@ -87,14 +73,7 @@ def swagger_users_retriveupdatedestroy():
             responses={
                 200: OpenApiResponse(
                     description="Successful operation",
-                    response=OpenApiTypes.OBJECT,
-                    examples=[
-                        OpenApiExample(
-                            "success",
-                            value=user_serializer_response,
-                            status_codes=["200"],
-                        )
-                    ],
+                    response=UserSerializer,
                 ),
                 401: OpenApiResponse(description="Unauthorized"),
                 404: OpenApiResponse(description="User not found"),


### PR DESCRIPTION
Instead of creating OpenApiExample to the response attribute of OpenApiResponse, Assign the respective serializer to the response attribute.